### PR TITLE
Use internalization on search string (mobile menu)

### DIFF
--- a/layout/_partial/mobile-nav.ejs
+++ b/layout/_partial/mobile-nav.ejs
@@ -2,5 +2,5 @@
   <% for (var i in theme.menu){ %>
     <a href="<%- url_for(theme.menu[i]) %>" class="mobile-nav-link"><%= i %></a>
   <% } %>
-  <a href="#search" class="mobile-nav-link st-search-show-outputs">Search</a>
+  <a href="#search" class="mobile-nav-link st-search-show-outputs"><%= __('search') %></a>
 </nav>


### PR DESCRIPTION
On my previous PR, I didn't see Search text was hardcoded in the mobile menu too. This fix that.